### PR TITLE
Update externals to cesm2_3_beta16

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -4,7 +4,7 @@ protocol = externals_only
 required = True
 
 [cam]
-tag = cam6_3_071
+tag = cam6_3_116
 protocol = git
 repo_url = https://github.com/ESCOMP/CAM
 local_path = components/cam
@@ -12,7 +12,7 @@ externals = Externals_CAM.cfg
 required = True
 
 [cice6]
-tag = cesm_cice6_2_0_22
+tag = cesm_cice6_4_1_9
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE
 local_path = components/cice
@@ -27,14 +27,14 @@ local_path = components/cice5
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.38
+tag = ccs_config_cesm0.0.71
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cdeps]
-tag = cdeps0.12.65
+tag = cdeps1.0.14
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS
 local_path = components/cdeps
@@ -42,21 +42,21 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cmeps]
-tag = cmeps0.13.71
+tag = cmeps0.14.34
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS
 local_path = components/cmeps
 required = True
 
 [cpl7]
-tag = cpl7.0.14
+tag = cpl77.0.5
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
 required = True
 
 [share]
-tag = share1.0.13
+tag = share1.0.17
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_share
 local_path = share
@@ -70,7 +70,7 @@ local_path = libraries/mct
 required = True
 
 [parallelio]
-tag = pio2_5_7
+tag = pio2_5_10
 protocol = git
 repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio
@@ -79,10 +79,8 @@ required = True
 [cime]
 local_path = cime
 protocol = git
-#repo_url = https://github.com/ESMCI/cime
-repo_url = https://github.com/ekluzek/cime
-#tag = cime6.0.71
-hash = 9bbadb3b173c57f00ff8666790a474951e28391d
+repo_url = https://github.com/ESMCI/cime
+tag = cime6.0.132
 required = True
 
 [externals_description]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -80,7 +80,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime6.0.132
+tag = cime6.0.140
 required = True
 
 [externals_description]

--- a/cime_config/testdefs/testlist_slim.xml
+++ b/cime_config/testdefs/testlist_slim.xml
@@ -74,7 +74,7 @@
   <!-- Don't run on CGD clusters because these are more expensive and not needed to run there for science -->
   <!-- for this the 2000 case is the most important, but should also do a global uniform case for 2000 -->
   <!-- need debug on and off, intel and gnu compilers and restart tests for the 2000 case-->
-  <!-- PEM tests should ONLY be with DOCN -->
+  <!-- PEM tests should ONLY be with DOCN, but let's just do PEM tests for I compsets  -->
   <!-- Run one longer test with production compiler for a few months to make sure longer science runs will continue to work -->
   <!-- The important science simualtions for this configuration is the 2000_CMIP6_AMIP_ensemble case for Wenwen -->
 
@@ -113,16 +113,6 @@
     <options>
       <option name="wallclock">01:40:00</option>
       <option name="comment">Longer smoke test with DOCN for realistic 2000 w CICE6</option>
-    </options>
-  </test>
-  <test name="PEM_Vnuopc" grid="f19_f19_mg16" compset="FLT2000ClimoC6I6Slim" testmods="slim/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_slim"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock">01:00:00</option>
-      <option name="comment">change Processors test with DOCN for realistic 2000 w CICE6</option>
     </options>
   </test>
   <test name="ERS_Ld60_Vnuopc" grid="f19_f19_mg16" compset="FLT2000ClimoC6I6Slim" testmods="slim/Monthly">
@@ -164,16 +154,6 @@
     <options>
       <option name="wallclock">01:40:00</option>
       <option name="comment">Longer smoke test with DOCN for realistic 2000</option>
-    </options>
-  </test>
-  <test name="PEM_Vmct_P144x1" grid="f19_f19_mg16" compset="FLT2000ClimoC6I5Slim" testmods="slim/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_slim"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock">01:00:00</option>
-      <option name="comment">change Processors test with DOCN for realistic 2000</option>
     </options>
   </test>
 

--- a/cime_config/testdefs/testlist_slim.xml
+++ b/cime_config/testdefs/testlist_slim.xml
@@ -166,7 +166,7 @@
       <option name="comment">Longer smoke test with DOCN for realistic 2000</option>
     </options>
   </test>
-  <test name="PEM_Vmct" grid="f19_f19_mg16" compset="FLT2000ClimoC6I5Slim" testmods="slim/default">
+  <test name="PEM_Vmct_P144x1" grid="f19_f19_mg16" compset="FLT2000ClimoC6I5Slim" testmods="slim/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_slim"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>

--- a/cime_config/testdefs/testlist_slim.xml
+++ b/cime_config/testdefs/testlist_slim.xml
@@ -203,6 +203,7 @@
       <machine name="cheyenne" compiler="gnu"   category="aux_slim"/>
       <machine name="cheyenne" compiler="gnu"   category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="aux_slim"/>
+      <machine name="cheyenne" compiler="nvhpc" category="aux_slim"/>
       <machine name="izumi" compiler="gnu"   category="aux_slim"/>
       <machine name="izumi" compiler="nag"   category="aux_slim"/>
       <machine name="izumi" compiler="intel" category="aux_slim"/>
@@ -288,6 +289,7 @@
       <machine name="cheyenne" compiler="intel" category="aux_slim"/>
       <machine name="cheyenne" compiler="gnu"   category="aux_slim"/>
       <machine name="cheyenne" compiler="gnu"   category="prebeta"/>
+      <machine name="cheyenne" compiler="nvhpc" category="aux_slim"/>
       <machine name="cheyenne" compiler="intel" category="slim_sci"/>
       <machine name="izumi"    compiler="intel" category="aux_slim"/>
       <machine name="izumi"    compiler="nag"   category="aux_slim"/>


### PR DESCRIPTION
Update externals to cesm2_3_beta16. cime is updated a little further to the tag with the testslim testlist name updated.

Fixes #89 by increasing the number of processors for the PEM tests